### PR TITLE
:bug: Return default color not undefined

### DIFF
--- a/frontend/src/hooks/useColorTransferFunction.ts
+++ b/frontend/src/hooks/useColorTransferFunction.ts
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 import { useColors } from '../stores/colors';
 import { makeStats } from '../stores/dataset/statisticsFactory';
 import { ColumnData } from '../types';
+import { NO_DATA as NO_DATA_COLOR } from '../palettes';
 
 const MAX_VALUES_FOR_INT_CATEGORY = 100;
 
@@ -84,7 +85,7 @@ export const createCategoricalTransferFunction = (
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const tf = ((val: any) => {
-        return colorMap.get(val);
+        return colorMap.get(val) ?? NO_DATA_COLOR;
     }) as CategoricalTransferFunction;
 
     tf.kind = 'categorical';

--- a/frontend/src/palettes.ts
+++ b/frontend/src/palettes.ts
@@ -2,7 +2,7 @@ import chroma from 'chroma-js';
 import _ from 'lodash';
 import { theme as twTheme } from 'twin.macro';
 
-const NO_DATA = chroma(twTheme`colors.gray.200`);
+export const NO_DATA = chroma(twTheme`colors.gray.200`);
 
 // note: the return value of the twin.macro theme has an incompatible type but is actually
 // replaced by a compatible string for the css colors, hence the complicated type conversion


### PR DESCRIPTION
Create Categorical TransferFunctions with a fallback in case value is not represented in the map and return default NO_DATA color instead

closes #28 