### PR TITLE
:sparkles: Add copy Cell Value/Column Name fo DataGrid

### DIFF
--- a/frontend/src/icons/Copy.tsx
+++ b/frontend/src/icons/Copy.tsx
@@ -1,0 +1,9 @@
+import type { IconType } from 'react-icons';
+import { RiFileCopyLine } from 'react-icons/ri';
+import tw from 'twin.macro';
+
+const Docs: IconType = tw(
+    RiFileCopyLine
+)`w-4 h-4 font-bold inline-block align-middle stroke-current`;
+
+export default Docs;

--- a/frontend/src/widgets/DataGrid/Cell/CellContextMenu.tsx
+++ b/frontend/src/widgets/DataGrid/Cell/CellContextMenu.tsx
@@ -4,6 +4,7 @@ import DeleteIcon from '../../../icons/Delete';
 import EditIcon from '../../../icons/Edit';
 import FilterIcon from '../../../icons/Filter';
 import HideIcon from '../../../icons/Hide';
+import CopyIcon from '../../../icons/Copy';
 import UncheckedIcon from '../../../icons/Unchecked';
 import Button from '../../../components/ui/Button';
 import { useContextMenu } from '../../../components/ui/ContextMenu';
@@ -17,6 +18,7 @@ import { DataColumn, IndexArray, PredicateFilter } from '../../../types';
 import { useColumn, useVisibleColumns } from '../context/columnContext';
 import useCellValue from '../hooks/useCellValue';
 import NeedsUpgradeButton from '../../../components/ui/NeedsUpgradeButton';
+import { notify } from '../../../notify';
 
 export interface Props {
     columnIndex: number;
@@ -78,6 +80,14 @@ const CellContextMenu: FunctionComponent<Props> = ({ columnIndex, rowIndex }) =>
         hideContextMenu();
         hideColumn(column.key);
     }, [column?.key, hideContextMenu, hideColumn]);
+
+    const onClickCopyCellValue = useCallback(() => {
+        navigator.clipboard
+            .writeText(value?.toString() ?? '')
+            .then(() => notify('Cell Value Copied to Clipboard'))
+            .catch((error) => console.error(error));
+        hideContextMenu();
+    }, [value, hideContextMenu]);
 
     if (!column) return <></>;
 
@@ -152,6 +162,11 @@ const CellContextMenu: FunctionComponent<Props> = ({ columnIndex, rowIndex }) =>
                     caption="Duplicate Row"
                     icon={<AddIcon />}
                     needsUpgrade={true}
+                />
+                <Action
+                    caption="Copy Cell Value"
+                    icon={<CopyIcon />}
+                    onClick={onClickCopyCellValue}
                 />
             </Menu>
         </>

--- a/frontend/src/widgets/DataGrid/Cell/HeaderCell.tsx
+++ b/frontend/src/widgets/DataGrid/Cell/HeaderCell.tsx
@@ -115,6 +115,8 @@ const HeaderCell: FunctionComponent<Props> = ({ style, columnIndex }) => {
             tw="border-r border-b px-1 border-collapse border-solid border-gray-400 w-full h-full flex flex-row overflow-hidden items-center"
             style={style}
             onClick={onToggleSorting}
+            data-columnindex={columnIndex}
+            data-rowindex={-1}
         >
             <div tw="flex-grow flex-shrink truncate">
                 <Tooltip tw="overflow-hidden w-full" content={tooltipContent}>

--- a/frontend/src/widgets/DataGrid/Cell/HeaderCellContextMenu.tsx
+++ b/frontend/src/widgets/DataGrid/Cell/HeaderCellContextMenu.tsx
@@ -1,0 +1,58 @@
+import CopyIcon from '../../../icons/Copy';
+import Button from '../../../components/ui/Button';
+import { useContextMenu } from '../../../components/ui/ContextMenu';
+import Menu from '../../../components/ui/Menu';
+import { ComponentProps, FunctionComponent, useCallback } from 'react';
+import 'twin.macro';
+import { useColumn } from '../context/columnContext';
+import { notify } from '../../../notify';
+
+export interface Props {
+    columnIndex: number;
+}
+
+interface ActionProps {
+    caption: string;
+    icon: JSX.Element;
+    onClick?: ComponentProps<typeof Button>['onClick'];
+}
+const Action = ({ caption, icon, onClick }: ActionProps) => {
+    return (
+        <Menu.Item>
+            <Button onClick={onClick}>
+                {icon}
+                <span tw="ml-1 font-normal">{caption}</span>
+            </Button>
+        </Menu.Item>
+    );
+};
+
+const CellContextMenu: FunctionComponent<Props> = ({ columnIndex }) => {
+    const column = useColumn(columnIndex);
+
+    const { hide: hideContextMenu } = useContextMenu();
+
+    const onClickCopyColumnName = useCallback(() => {
+        navigator.clipboard
+            .writeText(column.name)
+            .then(() => notify('Column Name Copied to Clipboard'))
+            .catch((error) => console.error(error));
+        hideContextMenu();
+    }, [column.name, hideContextMenu]);
+
+    if (!column) return <></>;
+
+    return (
+        <>
+            <Menu>
+                <Action
+                    caption="Copy Column Name"
+                    icon={<CopyIcon />}
+                    onClick={onClickCopyColumnName}
+                />
+            </Menu>
+        </>
+    );
+};
+
+export default CellContextMenu;

--- a/frontend/src/widgets/DataGrid/DataGrid.tsx
+++ b/frontend/src/widgets/DataGrid/DataGrid.tsx
@@ -15,6 +15,7 @@ import { TableViewProvider } from './context/tableViewContext';
 import HeaderGrid from './HeaderGrid';
 import MenuBar from './MenuBar';
 import TableGrid from './TableGrid';
+import GridContextMenu from './GridContextMenu';
 
 const headerHeight = 24;
 
@@ -84,18 +85,20 @@ const DataGrid: Widget = () => {
                             <AutoSizer>
                                 {({ width, height }) => (
                                     <div tw="bg-white" style={{ width, height }}>
-                                        <div tw="bg-gray-100 w-full">
-                                            <HeaderGrid
-                                                width={width - scrollbarWidth}
-                                                height={headerHeight}
-                                                ref={headerGrid}
+                                        <GridContextMenu>
+                                            <div tw="bg-gray-100 w-full">
+                                                <HeaderGrid
+                                                    width={width - scrollbarWidth}
+                                                    height={headerHeight}
+                                                    ref={headerGrid}
+                                                />
+                                            </div>
+                                            <TableGrid
+                                                width={width}
+                                                height={height - headerHeight}
+                                                onScroll={handleScroll}
                                             />
-                                        </div>
-                                        <TableGrid
-                                            width={width}
-                                            height={height - headerHeight}
-                                            onScroll={handleScroll}
-                                        />
+                                        </GridContextMenu>
                                     </div>
                                 )}
                             </AutoSizer>

--- a/frontend/src/widgets/DataGrid/GridContextMenu.tsx
+++ b/frontend/src/widgets/DataGrid/GridContextMenu.tsx
@@ -2,6 +2,7 @@ import ContextMenu from '../../components/ui/ContextMenu';
 import { FunctionComponent, MouseEvent, ReactNode, useCallback, useState } from 'react';
 import tw from 'twin.macro';
 import CellContextMenu from './Cell/CellContextMenu';
+import HeaderCellContextMenu from './Cell/HeaderCellContextMenu';
 
 const MenuWrapper = tw.div`
 w-full h-full`;
@@ -28,12 +29,15 @@ const GridContextMenu: FunctionComponent<Props> = ({ className, children }) => {
         <MenuWrapper onContextMenu={onContextMenu} className={className}>
             <ContextMenu
                 content={
-                    columnIndex >= 0 &&
-                    rowIndex >= 0 && (
+                    columnIndex >= 0 && rowIndex >= 0 ? (
                         <CellContextMenu
                             columnIndex={columnIndex}
                             rowIndex={rowIndex}
                         />
+                    ) : (
+                        columnIndex >= 0 && (
+                            <HeaderCellContextMenu columnIndex={columnIndex} />
+                        )
                     )
                 }
             >

--- a/frontend/src/widgets/DataGrid/TableGrid.tsx
+++ b/frontend/src/widgets/DataGrid/TableGrid.tsx
@@ -10,7 +10,6 @@ import {
     useVisibleColumns,
 } from './context/columnContext';
 import getRowHeight from './getRowHeight';
-import GridContextMenu from './GridContextMenu';
 import useHighlight from './hooks/useHighlight';
 import useRowCount from './hooks/useRowCount';
 import useSort from './hooks/useSort';

--- a/frontend/src/widgets/DataGrid/TableGrid.tsx
+++ b/frontend/src/widgets/DataGrid/TableGrid.tsx
@@ -76,26 +76,24 @@ const TableGrid: FunctionComponent<Props> = ({ width, height, onScroll }) => {
     return (
         <KeyboardControls scrollToRow={scrollToRow}>
             <MouseControls>
-                <GridContextMenu>
-                    <Grid
-                        style={{ overflowY: 'scroll' }}
-                        width={width}
-                        height={height}
-                        columnCount={columnCount}
-                        rowCount={Math.max(1, rowCount)}
-                        columnWidth={columnWidth}
-                        estimatedColumnWidth={100}
-                        rowHeight={getRowHeight}
-                        itemKey={rowCount ? itemKey : undefined}
-                        estimatedRowHeight={24}
-                        overscanColumnCount={2}
-                        overscanRowCount={8}
-                        onScroll={handleScroll}
-                        ref={ref}
-                    >
-                        {rowCount ? Cell : CellPlaceholder}
-                    </Grid>
-                </GridContextMenu>
+                <Grid
+                    style={{ overflowY: 'scroll' }}
+                    width={width}
+                    height={height}
+                    columnCount={columnCount}
+                    rowCount={Math.max(1, rowCount)}
+                    columnWidth={columnWidth}
+                    estimatedColumnWidth={100}
+                    rowHeight={getRowHeight}
+                    itemKey={rowCount ? itemKey : undefined}
+                    estimatedRowHeight={24}
+                    overscanColumnCount={2}
+                    overscanRowCount={8}
+                    onScroll={handleScroll}
+                    ref={ref}
+                >
+                    {rowCount ? Cell : CellPlaceholder}
+                </Grid>
             </MouseControls>
         </KeyboardControls>
     );


### PR DESCRIPTION
HeaderCellContextMenu introduced and copy column name functionality added to id. Added copy cell value to CellContextMenu.

closes #22 